### PR TITLE
silenced an 'undeclared selector' warning in Xcode

### DIFF
--- a/TBXML-Code/TBXML.m
+++ b/TBXML-Code/TBXML.m
@@ -177,7 +177,7 @@
                 *error = [TBXML errorWithCode:D_TBXML_FILE_NOT_FOUND_IN_BUNDLE userInfo:userInfo];
             }
         } else {
-            SEL dataWithUncompressedContentsOfFile = @selector(dataWithUncompressedContentsOfFile:);
+            SEL dataWithUncompressedContentsOfFile = NSSelectorFromString(@"dataWithUncompressedContentsOfFile:");
             
             // Get uncompressed file contents if TBXML+Compression has been included
             if ([[NSData class] respondsToSelector:dataWithUncompressedContentsOfFile]) {


### PR DESCRIPTION
Warning will only show if you enable it in build settings, which I have the habit of doing.
