### PR TITLE
Added [super dealloc] to TBXML's dealloc method

### DIFF
--- a/TBXML-Code/TBXML.m
+++ b/TBXML-Code/TBXML.m
@@ -892,6 +892,7 @@
 		}
 	}
 	
+    [super dealloc];
 }
 
 - (TBXMLElement*) nextAvailableElement {


### PR DESCRIPTION
Just a single line change. TBXML's dealloc method previously did not call its [super dealloc]
