### PR TITLE
Prevent crashes when calling deprecated functions

### DIFF
--- a/TBXML-Code/TBXML.m
+++ b/TBXML-Code/TBXML.m
@@ -97,7 +97,8 @@
 	return self;
 }
 - (id)initWithXMLString:(NSString*)aXMLString {
-    return [self initWithXMLString:aXMLString error:nil];
+    NSError *error = nil;
+    return [self initWithXMLString:aXMLString error:&error];
 }
 
 - (id)initWithXMLString:(NSString*)aXMLString error:(NSError *__autoreleasing *)error {
@@ -130,7 +131,8 @@
 }
 
 - (id)initWithXMLData:(NSData*)aData {
-    return [self initWithXMLData:aData error:nil];
+    NSError *error = nil;
+    return [self initWithXMLData:aData error:&error];
 }
 
 - (id)initWithXMLData:(NSData*)aData error:(NSError **)error {
@@ -144,7 +146,8 @@
 }
 
 - (id)initWithXMLFile:(NSString*)aXMLFile {
-    return [self initWithXMLFile:aXMLFile error:nil];
+    NSError *error = nil;
+    return [self initWithXMLFile:aXMLFile error:&error];
 }
 
 - (id)initWithXMLFile:(NSString*)aXMLFile error:(NSError **)error {
@@ -159,7 +162,8 @@
 }
 
 - (id)initWithXMLFile:(NSString*)aXMLFile fileExtension:(NSString*)aFileExtension {
-    return [self initWithXMLFile:aXMLFile fileExtension:aFileExtension error:nil];
+    NSError *error = nil;
+    return [self initWithXMLFile:aXMLFile fileExtension:aFileExtension error:&error];
 }
 
 - (id)initWithXMLFile:(NSString*)aXMLFile fileExtension:(NSString*)aFileExtension error:(NSError **)error {
@@ -204,7 +208,8 @@
 }
 
 - (void) decodeData:(NSData*)data {
-    [self decodeData:data withError:nil];
+    NSError *error = nil;
+    [self decodeData:data withError:&error];
 }
 
 - (void) decodeData:(NSData*)data withError:(NSError **)error {

--- a/TBXML-Tests/TBXMLTests.m
+++ b/TBXML-Tests/TBXMLTests.m
@@ -234,6 +234,21 @@
     STAssertTrue([value isEqualToString:@""], @"Returned string is not empty");
 }
 
+- (void)testDeprecated_tbxmlWithXMLData
+{
+    NSString *string = @"abcdefg";
+    NSData *data = [string dataUsingEncoding:NSUTF8StringEncoding];
+    
+    TBXML *tbxml = [TBXML tbxmlWithXMLData:data];
+    STAssertTrue(tbxml.rootXMLElement == nil, @"Should have failed to parse");
+    
+    string = @"<?xml version=\"1.0\"?><root><child>Element Text</child></root>";
+    data = [string dataUsingEncoding:NSUTF8StringEncoding];
+    
+    tbxml = [TBXML tbxmlWithXMLData:data];
+    STAssertTrue(tbxml.rootXMLElement != nil, @"Should have parsed successfully");
+}
+
 @end
 
 


### PR DESCRIPTION
Deprecated functions such as `+[TBXML tbxmlWithXMLData:]` were passing a null `error` pointer to other methods. This leads to a crash if an error occurs and the error-handling code doesn't check for a null pointer before setting the error.

These methods are deprecated, so callers shouldn't be using them, but legacy code should not crash.

This commit solves that problem by creating a local `NSError` reference and passing a pointer to that. For example:

```
- (id)initWithXMLData:(NSData*)aData {
    NSError *error = nil;
    return [self initWithXMLData:aData error:&error];
}
```

A test case has been added. This test case crashed before the fixes were made.
