### PR TITLE
Remove warning: Using 'stringWithString:' with a literal is redundant

### DIFF
--- a/TBXML-Code/TBXML.m
+++ b/TBXML-Code/TBXML.m
@@ -370,7 +370,7 @@
             if (attribute->value[0])
                 value = [NSString stringWithCString:&attribute->value[0] encoding:NSUTF8StringEncoding];
             else
-                value = [NSString stringWithString:@""];
+                value = @"";
             
 			break;
 		}


### PR DESCRIPTION
Remove warning: Using 'stringWithString:' with a literal is redundant
