### PR TITLE
The static TBXML helper methods to get name/text/values out of elements will crash if you pass a nil element.

### DIFF
--- a/TBXML-Code/TBXML.m
+++ b/TBXML-Code/TBXML.m
@@ -256,7 +256,7 @@
 @implementation TBXML (StaticFunctions)
 
 + (NSString*) elementName:(TBXMLElement*)aXMLElement {
-	if (nil == aXMLElement->name) return @"";
+	if (nil == aXMLElement || nil == aXMLElement->name) return @"";
 	return [NSString stringWithCString:&aXMLElement->name[0] encoding:NSUTF8StringEncoding];
 }
 
@@ -277,7 +277,7 @@
 }
 
 + (NSString*) attributeName:(TBXMLAttribute*)aXMLAttribute {
-	if (nil == aXMLAttribute->name) return @"";
+	if (nil == aXMLAttribute || nil == aXMLAttribute->name) return @"";
 	return [NSString stringWithCString:&aXMLAttribute->name[0] encoding:NSUTF8StringEncoding];
 }
 
@@ -299,7 +299,7 @@
 
 
 + (NSString*) attributeValue:(TBXMLAttribute*)aXMLAttribute {
-	if (nil == aXMLAttribute->value) return @"";
+	if (nil == aXMLAttribute || nil == aXMLAttribute->value) return @"";
 	return [NSString stringWithCString:&aXMLAttribute->value[0] encoding:NSUTF8StringEncoding];
 }
 
@@ -314,7 +314,7 @@
 }
 
 + (NSString*) textForElement:(TBXMLElement*)aXMLElement {
-	if (nil == aXMLElement->text) return @"";
+	if (nil == aXMLElement || nil == aXMLElement->text) return @"";
 	return [NSString stringWithCString:&aXMLElement->text[0] encoding:NSUTF8StringEncoding];
 }
 


### PR DESCRIPTION
Added nil checks for [TBXML elementName:], [TBXML attributeName:], [TBXML attributeValue:], and [TBXML textForElement:], if you pass in nil you will receive an EXC_BAD_ACCESS instead of returning empty string.
