### PR TITLE
Bugfixes, removed 2 compiler warnings and code cleanup

### DIFF
--- a/TBXML-Headers/TBXML.h
+++ b/TBXML-Headers/TBXML.h
@@ -47,6 +47,7 @@ enum TBXMLErrorCodes {
     D_TBXML_ELEMENT_TEXT_IS_NIL,
     D_TBXML_ATTRIBUTE_IS_NIL,
     D_TBXML_ATTRIBUTE_NAME_IS_NIL,
+    D_TBXML_ATTRIBUTE_VALUE_IS_NIL,
     D_TBXML_ATTRIBUTE_NOT_FOUND,
     D_TBXML_PARAM_NAME_IS_NIL
 };
@@ -170,8 +171,8 @@ typedef void (^TBXMLIterateAttributeBlock)(TBXMLAttribute *attribute, NSString *
 - (id)initWithXMLFile:(NSString*)aXMLFile fileExtension:(NSString*)aFileExtension __attribute__((deprecated));
 
 
-- (int) decodeData:(NSData*)data;
-- (int) decodeData:(NSData*)data withError:(NSError **)error;
+- (NSInteger) decodeData:(NSData*)data;
+- (NSInteger) decodeData:(NSData*)data withError:(NSError **)error;
 
 @end
 


### PR DESCRIPTION
- The methods "decodeData:" and "decodeData:withError:" now return an NSInteger in order to remove compiler warnings.
- "elementName:" now recalls "elementName:error:" in order to clean up the code and remove the crash in case "aXMLElement" is nil.
- "attributeName:" now recalls "attributeName:error:" in order to clean up the code and remove the crash in case "aXMLAttribute" is nil.
- "attributeValue:" now recalls "attributeValue:error:" in order to clean up the code and remove the crash in case "aXMLAttribute" is nil. Moreover a new error code has been added "D_TBXML_ATTRIBUTE_VALUE_IS_NIL" (with its related error description "Attribute value is nil"), in order to avoid a crash in case the value of an attribute is nil.
- "textForElement:" now recalls "textForElement:error:" in order to clean up the code and remove the crash in case "aXMLElement" is nil.
- "valueOfAttributeNamed:forElement:" now recalls "valueOfAttributeNamed:forElement:error:" in order to clean up the code and remove the crash in case "aName" or "aXMLElement" are nil. Moreover a compiler warning has been removed in this method.
- "childElementNamed:parentElement:" now recalls "childElementNamed:parentElement:error:" in order to clean up the code and remove the crash in case "aName" or "aParentXMLElement" are nil.
- "nextSiblingNamed:searchFromElement:" now recalls "nextSiblingNamed:searchFromElement:error:" in order to clean up the code and remove the crash in case "aName" or "aXMLElement" are nil.
