### PR TITLE
Add support for Xcode version 5.0.1 and added simple query in text example

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,5 @@
-
 (NOTE: This is an update of original 71squared/TBXML. I don't know if the main author is still active there.
-But I know my version of it does compile on iOS devices and works with Xcode 5.0.1. -- flagsoft)
+But I know my version of it does compile on iOS devices and works with Xcode 5.0.1. -- flagsoft, 14.NOV.2013)
 
 ### What is TBXML
 

--- a/README.markdown
+++ b/README.markdown
@@ -1,3 +1,7 @@
+
+(NOTE: This is an update of original 71squared/TBXML. I don't know if the main author is still active there.
+But I know my version of it does compile on iOS devices and works with Xcode 5.0.1. -- flagsoft)
+
 ### What is TBXML
 
 TBXML is a light-weight XML document parser written in Objective-C designed for use on Apple iPad, iPhone & iPod Touch devices (also Mac OSX compatible). TBXML aims to provide the fastest possible XML parsing whilst utilising the fewest resources. This requirement for absolute efficiency is achieved at the expense of XML validation and modification. It is not possible to modify and generate valid XML from a TBXML object and no validation is performed whatsoever whilst importing and parsing an XML document.

--- a/TBXML-Code/TBXML+Compression.m
+++ b/TBXML-Code/TBXML+Compression.m
@@ -230,7 +230,7 @@ static char encodingTable[64] = {
 	strm.opaque = Z_NULL;
 	strm.total_out = 0;
 	strm.next_in=(Bytef *)[self bytes];
-	strm.avail_in = [self length];
+	strm.avail_in = (unsigned int)[self length];  // Implicit vonversion loses integer precision: 'NSUInteger' (aka 'unsigned long') to 'uInt' (aka 'unsigned int')
 	
 	// Compresssion Levels:
 	//   Z_NO_COMPRESSION

--- a/TBXML-Code/TBXML+HTTP.m
+++ b/TBXML-Code/TBXML+HTTP.m
@@ -16,7 +16,7 @@
 	[request setURL:url];
 	[request setHTTPMethod:@"GET"];
     
-    
+
 #ifndef ARC_ENABLED
     return [request autorelease];
 #else
@@ -34,7 +34,7 @@
 	}
 	
 	NSData * postData = [[params componentsJoinedByString:@"&"] dataUsingEncoding:NSASCIIStringEncoding allowLossyConversion:YES];
-	NSString *postLength = [NSString stringWithFormat:@"%d", [postData length]];
+	NSString *postLength = [NSString stringWithFormat:@"%lu", (unsigned long)[postData length]];
 	
 	NSMutableURLRequest *request = [[NSMutableURLRequest alloc] init];
 	[request setURL:url];

--- a/TBXML-Code/TBXML.m
+++ b/TBXML-Code/TBXML.m
@@ -370,7 +370,7 @@
             if (attribute->value[0])
                 value = [NSString stringWithCString:&attribute->value[0] encoding:NSUTF8StringEncoding];
             else
-                value = [NSString stringWithString:@""];
+                value = @"";  // Xcode Version 5.0.1 (5A2053): Using 'stringWithString:' with a literal is redundant
             
 			break;
 		}

--- a/TBXML-Support/TBXML-iOS-Prefix.pch
+++ b/TBXML-Support/TBXML-iOS-Prefix.pch
@@ -4,4 +4,54 @@
 
 #ifdef __OBJC__
     #import <Foundation/Foundation.h>
+
+    // -- NOTE: This code seems to was missing here for iOS targets with Xcode Version 5.0.1 (5A2053). I copied it 1:1 from file "TBXML-Prefix.pch"
+
+    // define some LLVM3 macros if the code is compiled with a different compiler (ie LLVMGCC42)
+    #ifndef __has_feature
+    #define __has_feature(x) 0
+    #endif
+
+    #ifndef __has_extension
+    #define __has_extension __has_feature // Compatibility with pre-3.0 compilers.
+    #endif
+
+    #if __has_feature(objc_arc) && __clang_major__ >= 3
+    #define ARC_ENABLED 1
+    #endif // __has_feature(objc_arc)
+
+
+    // not using clang LLVM compiler, or LLVM version is not 3.x
+    #if !defined(__clang__) || __clang_major__ < 3
+
+    #ifndef __bridge
+    #define __bridge
+    #endif
+
+    #ifndef __bridge_retained
+    #define __bridge_retained
+    #endif
+
+    #ifndef __bridge_transfer
+    #define __bridge_transfer
+    #endif
+
+    #ifndef __autoreleasing
+    #define __autoreleasing
+    #endif
+
+    #ifndef __strong
+    #define __strong
+    #endif
+
+    #ifndef __weak
+    #define __weak
+    #endif
+
+    #ifndef __unsafe_unretained
+    #define __unsafe_unretained
+    #endif
+
+    #endif // __clang_major__ < 3
+
 #endif

--- a/TBXML-Tests/TBXMLTests.m
+++ b/TBXML-Tests/TBXMLTests.m
@@ -41,6 +41,154 @@
     STAssertNil(error, @"Incorrect Error Returned %@ %@", [error localizedDescription], [error userInfo]);
 }
 
+
+/*
+ 
+ <?xml version="1.0"?>
+ <authors>
+ 
+    <author name="AUTHOR NAME">
+        <book title="TITLE" price="1.10">
+ 
+            <description>
+                Descr A
+            </description>
+        </book>
+ 
+        <book title="TITLE B" price="2.20">
+            <description>
+                    Descr B
+            </description>
+        </book>
+
+    </author>
+
+</authors>
+
+ */
+
+//NSMutableArray *records;
+
+- (void)testSimpleQuery_main
+{
+    NSError *error;
+    TBXML *tbxml;
+
+    
+    //records = [NSMutableArray array];
+    
+    tbxml = [TBXML newTBXMLWithXMLFile:@"books.xml" error:&error];
+
+    if (tbxml.rootXMLElement) {
+        [self testSimpleQuery_traverseElement:tbxml.rootXMLElement];
+    } else {
+       NSLog(@"ERROR");
+        STAssertTrue([error code] == D_TBXML_DATA_NIL, @"Incorrect Error Returned %@ %@", [error localizedDescription], [error userInfo]);
+    }
+
+}
+
+- (void) testSimpleQuery_traverseElement:(TBXMLElement *)element {
+    
+    do {
+        
+        //
+        // Display the name of the element
+        //
+
+        /*NSLog(@"\n");
+        NSLog(@"-----------------------------------------------------");
+        NSLog(@"- TBXML elementName = %@", [TBXML elementName:element]);*/
+
+    
+        //
+        // -- match /authors/author
+        //
+        
+        if ([[TBXML elementName:element] isEqualToString:@"author"]) {
+
+            // -- get //author/@name
+            TBXMLAttribute *attribute = element->firstAttribute;
+            NSString *myAuthor = [TBXML attributeValue:attribute];
+
+            NSLog(@"-----------------------------------------------------");
+            NSLog(@"-+ //author/@name = \"%@\"", myAuthor);
+            
+        }
+
+        //
+        // -- match /authors/author/book
+        //
+        
+        if ([[TBXML elementName:element] isEqualToString:@"book"]) {
+            
+            // -- ok, we got book
+          
+            //  <book title="TITLE" price="1.10">
+
+            TBXMLAttribute *attribute = element->firstAttribute;
+            
+            NSString *myTitle = [TBXML attributeValue:attribute];  // note: we assume that the title attribut comes first
+            
+            attribute = attribute->next;  // point to next attribute (price here)
+            
+            NSString *myPrice = [TBXML attributeValue:attribute];
+            
+            NSLog(@" +- //author/book/@title: \"%@\"", myTitle);
+            NSLog(@" +- //author/book/@price: \"%@\"", myPrice);
+            
+        }
+        
+        if ([[TBXML elementName:element] isEqualToString:@"description"]) {
+            // -- ok, we got description
+            //  <description>Bla bla bla...</decriptiopn>
+            NSString * description = [TBXML textForElement:element];
+            NSLog(@"  \\- //author/book/description: \"%@\"", description);
+        }
+        
+    
+    
+        //
+        // -- display all XML ATTRIBUTES if any
+        // see: http://www.tbxml.co.uk/TBXML/Guides_-_Traversing_Unknown_elements___attributes.html
+
+        // Obtain first attribute from element
+        
+        /*
+         TBXMLAttribute *attribute = element->firstAttribute;
+
+        bool FLAG_thereAreAttributes = NO;
+        
+        while (attribute) {
+
+            // -- attribute is valid
+            FLAG_thereAreAttributes = YES;
+
+            // Display name and value of attribute to the log window
+            NSLog(@" -- XML-ATTRIBUT: //%@/@%@ = \"%@\"",
+                  [TBXML elementName:element],
+                  [TBXML attributeName:attribute],
+                  [TBXML attributeValue:attribute]);
+            
+            // Obtain the next attribute
+            attribute = attribute->next;
+        }
+
+        if (FLAG_thereAreAttributes == NO ) {
+            NSLog(@" -- XML-ATTRIBUT: (no attrubutes for this element)");
+        }
+        */
+
+        
+        if (element->firstChild) {
+            // do recursion
+            [self testSimpleQuery_traverseElement:element->firstChild];
+        }
+
+        
+    } while ((element = element->nextSibling));
+}
+
 - (void)testDataIsNil
 {   
     NSData *data = nil;

--- a/TBXML.xcodeproj/project.pbxproj
+++ b/TBXML.xcodeproj/project.pbxproj
@@ -309,7 +309,7 @@
 		829FA09314D5B52A00D18697 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0420;
+				LastUpgradeCheck = 0500;
 				ORGANIZATIONNAME = "71 Squared";
 			};
 			buildConfigurationList = 829FA09614D5B52A00D18697 /* Build configuration list for PBXProject "TBXML" */;
@@ -438,7 +438,6 @@
 		8290354414D9F5B200ACF7E4 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				DSTROOT = /tmp/TBXML_iOS.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "TBXML-Support/TBXML-iOS-Prefix.pch";
@@ -453,7 +452,6 @@
 		8290354514D9F5B200ACF7E4 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				DSTROOT = /tmp/TBXML_iOS.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "TBXML-Support/TBXML-iOS-Prefix.pch";
@@ -469,7 +467,6 @@
 		8290354614D9F5B200ACF7E4 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(DEVELOPER_LIBRARY_DIR)/Frameworks",
@@ -487,7 +484,6 @@
 		8290354714D9F5B200ACF7E4 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(DEVELOPER_LIBRARY_DIR)/Frameworks",
@@ -507,8 +503,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -523,6 +524,9 @@
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				ONLY_ACTIVE_ARCH = YES;
@@ -534,8 +538,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -544,6 +553,9 @@
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				SDKROOT = macosx;
@@ -571,6 +583,7 @@
 		829FA0C614D5B52A00D18697 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(DEVELOPER_LIBRARY_DIR)/Frameworks";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "TBXML-Support/TBXML-Prefix.pch";
@@ -583,6 +596,7 @@
 		829FA0C714D5B52A00D18697 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(DEVELOPER_LIBRARY_DIR)/Frameworks";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "TBXML-Support/TBXML-Prefix.pch";


### PR DESCRIPTION
Added support for Version 5.0.1 (5A2053) - can now build for iOS.
Added testSimpleQuery_main() test function with simple query example.
