### PR TITLE
Fixed imports

### DIFF
--- a/TBXML-Headers/TBXML+Compression.h
+++ b/TBXML-Headers/TBXML+Compression.h
@@ -1,3 +1,5 @@
+#import <Foundation/Foundation.h>
+
 @interface NSData (TBXML_Compression)
 
 // ================================================================================================

--- a/TBXML-Headers/TBXML.h
+++ b/TBXML-Headers/TBXML.h
@@ -26,7 +26,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 // ================================================================================================
-
+#import <Foundation/Foundation.h>
 @class TBXML;
 
 


### PR DESCRIPTION
This fix integrates fixed imports for Foundation library not depending of having a Prefix Headers file in your project
